### PR TITLE
Fix weird duplicating space issue

### DIFF
--- a/user-profile.ps1
+++ b/user-profile.ps1
@@ -63,7 +63,8 @@ function Write-GitPrompt() {
         Write-Host $arrowSymbol -NoNewLine -BackgroundColor $gitBackColor -ForegroundColor $pathBackColor
 
         # Write branch symbol and name
-        Write-Host " " $branchSymbol " " $status.Branch " " -NoNewLine -BackgroundColor $gitBackColor -ForegroundColor $gitForeColor
+        $branchString = [string]::Format(" {0} {1} ", $branchSymbol, $status.Branch)
+        Write-Host $branchString -NoNewLine -BackgroundColor $gitBackColor -ForegroundColor $gitForeColor
 
         <# Git status info
         HasWorking   : False
@@ -106,7 +107,8 @@ function tildaPath($Path) {
 # Replace the cmder prompt entirely with this.
 [ScriptBlock]$CmderPrompt = {
     $tp = tildaPath($pwd.ProviderPath)
-    Microsoft.PowerShell.Utility\Write-Host "`n" $tp " " -NoNewLine -BackgroundColor $pathBackColor -ForegroundColor $pathForeColor
+    $pathString = [string]::Format("`n{0} ", $tp)
+    Microsoft.PowerShell.Utility\Write-Host $pathString -NoNewLine -BackgroundColor $pathBackColor -ForegroundColor $pathForeColor
 
     getGitStatus($pwd.ProviderPath)
 }

--- a/user-profile.ps1
+++ b/user-profile.ps1
@@ -63,8 +63,7 @@ function Write-GitPrompt() {
         Write-Host $arrowSymbol -NoNewLine -BackgroundColor $gitBackColor -ForegroundColor $pathBackColor
 
         # Write branch symbol and name
-        $branchString = [string]::Format(" {0} {1} ", $branchSymbol, $status.Branch)
-        Write-Host $branchString -NoNewLine -BackgroundColor $gitBackColor -ForegroundColor $gitForeColor
+        Write-Host (" $($branchSymbol) $($status.Branch)") -NoNewLine -BackgroundColor $gitBackColor -ForegroundColor $gitForeColor
 
         <# Git status info
         HasWorking   : False
@@ -107,8 +106,7 @@ function tildaPath($Path) {
 # Replace the cmder prompt entirely with this.
 [ScriptBlock]$CmderPrompt = {
     $tp = tildaPath($pwd.ProviderPath)
-    $pathString = [string]::Format("`n{0} ", $tp)
-    Microsoft.PowerShell.Utility\Write-Host $pathString -NoNewLine -BackgroundColor $pathBackColor -ForegroundColor $pathForeColor
+    Microsoft.PowerShell.Utility\Write-Host ("`n$($tp) ") -NoNewLine -BackgroundColor $pathBackColor -ForegroundColor $pathForeColor
 
     getGitStatus($pwd.ProviderPath)
 }


### PR DESCRIPTION
I was getting a strange duplicating spaces issue seen here
![image](https://user-images.githubusercontent.com/1786930/37547297-3b3f9e82-2947-11e8-8dae-fff3bd6fd7dc.png)

After this change to using [string]::Format it looks like this
![image](https://user-images.githubusercontent.com/1786930/37547320-5a300c1e-2947-11e8-9850-9e448134a2f0.png)
