### PR TITLE
Add Powershell equivalent of `tail -f`

### DIFF
--- a/profile.d/tail.alias.ps1
+++ b/profile.d/tail.alias.ps1
@@ -1,0 +1,26 @@
+function tailFile(){
+<#
+.SYNOPSIS
+tail a File
+.DESCRIPTION
+Powershell equivalent of Unix `tail --follow`
+.PARAMETER filePath
+Path to the file to tail
+.INPUTS
+A text file
+.OUTPUTS
+Text added to the file in real-time
+#>
+
+    [CmdletBinding()]
+    Param(
+        [parameter(mandatory=$true,
+        HelpMessage="File to tail.")]
+        [ValidateScript({Test-Path $_})]
+        [String]
+        $filePath
+    )
+    Get-Content $filePath -Wait
+}
+
+Set-Alias -name "tail" -value "tailFile"


### PR DESCRIPTION
Powershell equivalent of Unix `tail --follow` or better known as `tail -f`.

This alias is born of the fact that this very handy command for most Unix users that are watching logs. This capability is certain to be useful to MS Windows developers too.

The underlying `Get-Content` command is fairly easy, yes. However, now, one does not need to look it up :-)

   --- Lionel Saliou, Ph.D